### PR TITLE
Apply Rustfmt

### DIFF
--- a/examples/complete.rs
+++ b/examples/complete.rs
@@ -1,28 +1,33 @@
 extern crate awesome_bot;
 
-use std::{thread, time};
-use std::iter::FromIterator;
 use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::{thread, time};
 
-use awesome_bot::{ AwesomeBot, Message, ReplyKeyboardMarkup, ChatAction, PhotoSize, Finisher, MessageType, Audio, Voice, Document, Sticker, Video, Float};
+use awesome_bot::{
+    Audio, AwesomeBot, ChatAction, Document, Finisher, Float, Message, MessageType, PhotoSize,
+    ReplyKeyboardMarkup, Sticker, Video, Voice,
+};
 
 macro_rules! debug {
-    ($e: expr) => {
+    ($e:expr) => {
         println!("{:?}", $e);
-    }
+    };
 }
 
 macro_rules! debug_msg {
-    ($m: expr, $t: expr) => {
+    ($m:expr, $t:expr) => {
         println!("<{}> {}", $m.from.first_name, $t);
     };
-    ($m: expr) => {
+    ($m:expr) => {
         println!("<{}>", $m.from.first_name);
-    }
+    };
 }
 
 fn transform(vecs: Vec<Vec<&str>>) -> Vec<Vec<String>> {
-    vecs.iter().map(|x| x.iter().map(|x| x.to_string()).collect()).collect()
+    vecs.iter()
+        .map(|x| x.iter().map(|x| x.to_string()).collect())
+        .collect()
 }
 
 fn cmd_keyboard(bot: &AwesomeBot, msg: &Message, _: String) {
@@ -36,7 +41,11 @@ fn cmd_keyboard(bot: &AwesomeBot, msg: &Message, _: String) {
 }
 
 fn test_async_hand(bot: &AwesomeBot, msg: &Message, _: String) {
-    debug!(bot.answer(msg).text("Starting, send me another command in the next 5 seconds...").end());
+    debug!(
+        bot.answer(msg)
+            .text("Starting, send me another command in the next 5 seconds...")
+            .end()
+    );
     thread::sleep(time::Duration::from_millis(5000));
     debug!(bot.answer(msg).text("End async test").end());
 }
@@ -63,24 +72,36 @@ fn show_me_hand(bot: &AwesomeBot, msg: &Message, _: String) {
         ("/hidekeyboard", "Hide the keyboard"),
         ("/hardecho", "Echo with force reply"),
         ("/forwardme", "Forward that message to you"),
-        ("/sleep", "Sleep for 5 seconds, without blocking, awesome goroutines"),
-        ("/showmecommands", "Returns you a keyboard with the simplest commands"),
+        (
+            "/sleep",
+            "Sleep for 5 seconds, without blocking, awesome goroutines",
+        ),
+        (
+            "/showmecommands",
+            "Returns you a keyboard with the simplest commands",
+        ),
         ("/sendimage", "Sends you an image"),
         ("/sendimagekey", "Sends you an image with a custom keyboard"),
         ("/senddocument", "Sends you a document"),
         ("/sendsticker", "Sends you a sticker"),
         ("/sendvideo", "Sends you a video"),
         ("/sendlocation", "Sends you a location"),
-        ("/sendchataction", "Sends a random chat action")]);
+        ("/sendchataction", "Sends a random chat action"),
+    ]);
 
-    let commands_k = divide_by_two(cmds.into_iter().map(|(x,_)| x));
+    let commands_k = divide_by_two(cmds.into_iter().map(|(x, _)| x));
     let kbl = ReplyKeyboardMarkup {
         keyboard: transform(commands_k),
         resize_keyboard: None,
         one_time_keyboard: Some(true),
         selective: None,
     };
-    debug!(bot.answer(msg).text("There you have the commands!").keyboard(kbl).end());
+    debug!(
+        bot.answer(msg)
+            .text("There you have the commands!")
+            .keyboard(kbl)
+            .end()
+    );
 }
 
 fn hide_keyboard(bot: &AwesomeBot, msg: &Message, _: String) {
@@ -96,7 +117,11 @@ fn hard_echo(bot: &AwesomeBot, msg: &Message, _: String, args: Vec<String>) {
 }
 
 fn hello_hand(bot: &AwesomeBot, msg: &Message, _: String) {
-    debug!(bot.answer(msg).text(&format!("Hi {}!", msg.from.first_name)).end());
+    debug!(
+        bot.answer(msg)
+            .text(&format!("Hi {}!", msg.from.first_name))
+            .end()
+    );
 }
 
 fn tell_me_hand(bot: &AwesomeBot, msg: &Message, _: String, args: Vec<String>) {
@@ -156,9 +181,18 @@ fn handaction(bot: &AwesomeBot, msg: &Message, _: String) {
 // =================
 
 fn transform_info_photos(v: Vec<PhotoSize>) -> String {
-    v.iter().map(|p| {
-        format!("Image of size ({} x {})\nID: {}\nSize: {}", p.width, p.height, p.file_id, p.file_size.unwrap_or(0))
-    }).collect::<Vec<_>>().join("\n----------\n")
+    v.iter()
+        .map(|p| {
+            format!(
+                "Image of size ({} x {})\nID: {}\nSize: {}",
+                p.width,
+                p.height,
+                p.file_id,
+                p.file_size.unwrap_or(0)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n----------\n")
 }
 
 fn photo_handler(bot: &AwesomeBot, msg: &Message, photos: Vec<PhotoSize>) {
@@ -177,19 +211,39 @@ fn voice_handler(bot: &AwesomeBot, msg: &Message, voice: Voice) {
 }
 
 fn document_handler(bot: &AwesomeBot, msg: &Message, document: Document) {
-    let mut message = format!("Information about the document:\nID: {}\nFile name: {}\nMimeType: {}\nFile size: {} Bytes", document.file_id, document.file_name.unwrap_or("No name".into()), document.mime_type.unwrap_or("No mime type".into()), document.file_size.unwrap_or(0));
+    let mut message = format!(
+        "Information about the document:\nID: {}\nFile name: {}\nMimeType: {}\nFile size: {} Bytes",
+        document.file_id,
+        document.file_name.unwrap_or("No name".into()),
+        document.mime_type.unwrap_or("No mime type".into()),
+        document.file_size.unwrap_or(0)
+    );
     if let Some(thumb) = document.thumb {
-        message = format!("{}\nAnd the information about the thumb:\n{}", message, transform_info_photos(vec![thumb]));
+        message = format!(
+            "{}\nAnd the information about the thumb:\n{}",
+            message,
+            transform_info_photos(vec![thumb])
+        );
     }
     // Add thumb
     debug!(bot.answer(msg).text(&message).end());
 }
 
 fn sticker_handler(bot: &AwesomeBot, msg: &Message, sticker: Sticker) {
-    let mut message = format!("Information about the sticker:\nID: {}\nWidth: {}\nHeight: {}\nFile size: {} Bytes", sticker.file_id, sticker.width, sticker.height, sticker.file_size.unwrap_or(0));
+    let mut message = format!(
+        "Information about the sticker:\nID: {}\nWidth: {}\nHeight: {}\nFile size: {} Bytes",
+        sticker.file_id,
+        sticker.width,
+        sticker.height,
+        sticker.file_size.unwrap_or(0)
+    );
     // Add thumb
     if let Some(thumb) = sticker.thumb {
-        message = format!("{}\nAnd the information about the thumb:\n{}", message, transform_info_photos(vec![thumb]));
+        message = format!(
+            "{}\nAnd the information about the thumb:\n{}",
+            message,
+            transform_info_photos(vec![thumb])
+        );
     }
     debug!(bot.answer(msg).text(&message).end());
 }
@@ -198,13 +252,20 @@ fn video_handler(bot: &AwesomeBot, msg: &Message, video: Video) {
     let mut message = format!("Information about the video:\nID: {}\nWidth: {}\nHeight: {}\nDuration: {}\nMime type: {}\nFile size: {} Bytes", video.file_id, video.width, video.height, video.duration, video.mime_type.unwrap_or("No mime type".into()), video.file_size.unwrap_or(0));
     // Add thumb
     if let Some(thumb) = video.thumb {
-        message = format!("{}\nThumb:\n{}", message, transform_info_photos(vec![thumb]));
+        message = format!(
+            "{}\nThumb:\n{}",
+            message,
+            transform_info_photos(vec![thumb])
+        );
     }
     debug!(bot.answer(msg).text(&message).end());
 }
 
 fn location_handler(bot: &AwesomeBot, msg: &Message, latitude: Float, longitude: Float) {
-    let message = format!("Information of location:\nLatitude: {}\nLongitude: {}", latitude, longitude);
+    let message = format!(
+        "Information of location:\nLatitude: {}\nLongitude: {}",
+        latitude, longitude
+    );
     debug!(bot.answer(msg).text(&message).end());
 }
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -1,5 +1,5 @@
+use rustc_serialize::Decodable;
 use telegram_bot::*;
-use rustc_serialize::{Decodable};
 
 /// Help trait indicating that at least the `end` method is implemented for the SendBuilder structs
 pub trait Finisher<T: Decodable> {
@@ -19,57 +19,117 @@ impl SendBuilder {
     /// Create a new SendBuilder, don't use it,
     /// use the `send` and `answer` methods of `AwesomeBot` :)
     pub fn new(id: Integer, bot: Api) -> SendBuilder {
-        SendBuilder { chat_id: id, bot: bot }
+        SendBuilder {
+            chat_id: id,
+            bot: bot,
+        }
     }
 
     /// Start a text constructor to send.
     pub fn text(self, t: &str) -> SendText {
-        SendText { send: self, text: t.to_string(), parse_mode: None, disable_webpage_preview: None, reply_to_message_id: None, reply_markup: None }
+        SendText {
+            send: self,
+            text: t.to_string(),
+            parse_mode: None,
+            disable_webpage_preview: None,
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
     }
 
     /// Start a photo constructor to send.
     pub fn photo(self, t: &str) -> SendPhoto {
-        SendPhoto { send: self, photo: t.to_string(), caption: None, reply_to_message_id: None, reply_markup: None }
+        SendPhoto {
+            send: self,
+            photo: t.to_string(),
+            caption: None,
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
     }
 
     /// Start an audio constructor to send.
     pub fn audio(self, t: &str) -> SendAudio {
-        SendAudio { send: self, audio: t.to_string(), duration: None, performer: None, title: None, reply_to_message_id: None, reply_markup: None }
+        SendAudio {
+            send: self,
+            audio: t.to_string(),
+            duration: None,
+            performer: None,
+            title: None,
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
     }
 
     /// Start a voice constructor to send.
     pub fn voice(self, t: &str) -> SendVoice {
-        SendVoice { send: self, voice: t.to_string(), duration: None, reply_to_message_id: None, reply_markup: None }
+        SendVoice {
+            send: self,
+            voice: t.to_string(),
+            duration: None,
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
     }
 
     /// Start a document constructor to send.
     pub fn document(self, t: &str) -> SendDocument {
-        SendDocument { send: self, document: t.to_string(), reply_to_message_id: None, reply_markup: None }
+        SendDocument {
+            send: self,
+            document: t.to_string(),
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
     }
 
     /// Start a sticker constructor to send.
     pub fn sticker(self, t: &str) -> SendSticker {
-        SendSticker { send: self, sticker: t.to_string(), reply_to_message_id: None, reply_markup: None }
+        SendSticker {
+            send: self,
+            sticker: t.to_string(),
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
     }
 
     /// Start a video constructor to send.
     pub fn video(self, t: &str) -> SendVideo {
-        SendVideo { send: self, video: t.to_string(), caption: None, duration: None, reply_to_message_id: None, reply_markup: None }
+        SendVideo {
+            send: self,
+            video: t.to_string(),
+            caption: None,
+            duration: None,
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
     }
 
     /// Start a forward constructor to send.
     pub fn forward(self, to: Integer, msg: Integer) -> SendForward {
-        SendForward { send: self, to: to, msg: msg }
+        SendForward {
+            send: self,
+            to: to,
+            msg: msg,
+        }
     }
 
     /// Start an action constructor to send.
     pub fn action(self, action: ChatAction) -> SendAction {
-        SendAction { send: self, action: action }
+        SendAction {
+            send: self,
+            action: action,
+        }
     }
 
     /// Start a location constructor to send.
     pub fn location(self, latitude: Float, longitude: Float) -> SendLocation {
-        SendLocation { send: self, latitude: latitude, longitude: longitude, reply_to_message_id: None, reply_markup: None }
+        SendLocation {
+            send: self,
+            latitude: latitude,
+            longitude: longitude,
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
     }
 }
 
@@ -103,8 +163,7 @@ macro_rules! basesendtype {
 }
 
 macro_rules! addkeyboardfuncs {
-    ($name: ident,
-     $markname: ident) => {
+    ($name:ident, $markname:ident) => {
         /// Add keyboard methods to the struct, only one of these will be sent,
         /// and it will be the last one used.
         impl $name {
@@ -126,7 +185,7 @@ macro_rules! addkeyboardfuncs {
                 self
             }
         }
-    }
+    };
 }
 
 basesendtype!(SendText,
@@ -147,7 +206,8 @@ impl Finisher<Message> for SendText {
             self.parse_mode,
             self.disable_webpage_preview,
             self.reply_to_message_id,
-            self.reply_markup.clone())
+            self.reply_markup.clone(),
+        )
     }
 }
 
@@ -168,7 +228,7 @@ impl Finisher<Message> for SendPhoto {
             self.caption.clone(),
             self.reply_to_message_id,
             self.reply_markup.clone(),
-            )
+        )
     }
 }
 
@@ -193,7 +253,7 @@ impl Finisher<Message> for SendAudio {
             self.title.clone(),
             self.reply_to_message_id,
             self.reply_markup.clone(),
-            )
+        )
     }
 }
 
@@ -214,7 +274,7 @@ impl Finisher<Message> for SendVoice {
             self.duration,
             self.reply_to_message_id,
             self.reply_markup.clone(),
-            )
+        )
     }
 }
 
@@ -233,10 +293,9 @@ impl Finisher<Message> for SendDocument {
             self.document.clone(),
             self.reply_to_message_id,
             self.reply_markup.clone(),
-            )
+        )
     }
 }
-
 
 basesendtype!(SendSticker,
               "`Sticker`",
@@ -253,7 +312,7 @@ impl Finisher<Message> for SendSticker {
             self.sticker.clone(),
             self.reply_to_message_id,
             self.reply_markup.clone(),
-            )
+        )
     }
 }
 
@@ -276,7 +335,7 @@ impl Finisher<Message> for SendVideo {
             self.duration,
             self.reply_to_message_id,
             self.reply_markup.clone(),
-            )
+        )
     }
 }
 
@@ -287,11 +346,9 @@ basesendtype!(SendForward,
 
 impl Finisher<Message> for SendForward {
     fn end(&mut self) -> Result<Message> {
-        self.send.bot.forward_message(
-            self.send.chat_id,
-            self.to,
-            self.msg,
-            )
+        self.send
+            .bot
+            .forward_message(self.send.chat_id, self.to, self.msg)
     }
 }
 
@@ -302,10 +359,9 @@ basesendtype!(SendAction,
 
 impl Finisher<bool> for SendAction {
     fn end(&mut self) -> Result<bool> {
-        self.send.bot.send_chat_action(
-            self.send.chat_id,
-            self.action,
-            )
+        self.send
+            .bot
+            .send_chat_action(self.send.chat_id, self.action)
     }
 }
 
@@ -325,6 +381,7 @@ impl Finisher<Message> for SendLocation {
             self.latitude,
             self.longitude,
             self.reply_to_message_id,
-            self.reply_markup.clone())
+            self.reply_markup.clone(),
+        )
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test {
-    use AwesomeBot;
     use regex::Regex;
+    use AwesomeBot;
 
     struct Defs {
         cmd: &'static str,
@@ -20,16 +20,16 @@ mod test {
     }
 
     macro_rules! create_test_string {
-        (
-            $name: ident,
-            $cmd: expr
-                ) => {
+        ($name:ident, $cmd:expr) => {
             #[test]
             fn $name() {
-                let defs = Defs{cmd: $cmd, ..Default::default()};
+                let defs = Defs {
+                    cmd: $cmd,
+                    ..Default::default()
+                };
                 assert_eq!(AwesomeBot::modify_command(defs.cmd, &defs.usern), defs.res);
             }
-        }
+        };
     }
     create_test_string!(mt_simple_right, "test");
     create_test_string!(mt_end_right, "test$");
@@ -40,11 +40,17 @@ mod test {
 
     #[test]
     fn test_complex_command() {
-        assert_eq!(AwesomeBot::modify_command("echo (.+)", "rock"), String::from("^/echo(?:@rock)? (.+)$"));
+        assert_eq!(
+            AwesomeBot::modify_command("echo (.+)", "rock"),
+            String::from("^/echo(?:@rock)? (.+)$")
+        );
     }
 
     fn create_regex(cmd: &'static str) -> Regex {
-        let defs = Defs{cmd: cmd, ..Default::default()};
+        let defs = Defs {
+            cmd: cmd,
+            ..Default::default()
+        };
         let cmd = AwesomeBot::modify_command(defs.cmd, &defs.usern);
         Regex::new(&*cmd).unwrap()
     }


### PR DESCRIPTION
Now before we move on with essential code changes, it makes sense to apply rustfmt so that code formatting is uniform.

There are no functional changes in this PR, only formatting applied by running rustfmt over all .rs files.